### PR TITLE
Add Streamlit UI for scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,21 @@ Optional parameters:
 - `--progress` path to the progress file (default `progress.txt`)
 
 Results for each chunk are saved as `result_<index>.json`. To restart the pipeline without repeating finished chunks, keep the progress file.
+
+## PDF Analyzer (Streamlit)
+
+`pdf_analyzer.py` is a Streamlit application for extracting structured information from PDF files using OpenAI models. It supports chunking, APA reference extraction and Excel export.
+
+Run it with:
+```bash
+streamlit run pdf_analyzer.py
+```
+
+## Scheduler Streamlit UI
+
+`scheduler_streamlit.py` exposes `openai_scheduler.py` through a simple Streamlit interface. You can upload a text file of chunks or paste text, set your API key and scheduling parameters, and monitor progress directly in the browser.
+
+Run it with:
+```bash
+streamlit run scheduler_streamlit.py
+```

--- a/scheduler_streamlit.py
+++ b/scheduler_streamlit.py
@@ -1,0 +1,68 @@
+import asyncio
+import json
+from pathlib import Path
+
+import streamlit as st
+
+from openai_scheduler import SchedulerConfig, OpenAIScheduler
+
+st.set_page_config(page_title="OpenAI Scheduler", page_icon="🤖")
+st.title("OpenAI Scheduler")
+
+source = st.radio("Source des chunks", ["Fichier", "Texte"], index=0)
+chunks = []
+if source == "Fichier":
+    uploaded = st.file_uploader("Fichier texte", type=["txt"])
+    if uploaded is not None:
+        content = uploaded.read().decode("utf-8")
+        chunks = [line.strip() for line in content.splitlines() if line.strip()]
+else:
+    text = st.text_area("Entrez un chunk par ligne")
+    if text:
+        chunks = [line.strip() for line in text.splitlines() if line.strip()]
+
+api_key = st.text_input("Clé API OpenAI", type="password")
+
+st.sidebar.header("Configuration")
+max_concurrent = st.sidebar.number_input("Concurrence max", value=15, min_value=1)
+interval = st.sidebar.number_input("Intervalle entre envois (s)", value=4.0, min_value=0.1, step=0.1)
+backoff = st.sidebar.number_input("Backoff initial (s)", value=1.0, min_value=0.1, step=0.1)
+retries = st.sidebar.number_input("Nombre de retries", value=3, min_value=0)
+progress_file = st.sidebar.text_input("Fichier de progrès", value="progress.txt")
+
+run = st.button("Lancer")
+
+if run:
+    if not chunks:
+        st.error("Aucun chunk fourni")
+    elif not api_key:
+        st.error("Clé API requise")
+    else:
+        results = []
+        progress_bar = st.progress(0)
+        status = st.empty()
+
+        def handler(idx, response):
+            if hasattr(response, "choices"):
+                content = response.choices[0].message.content
+            else:
+                content = str(response)
+            results.append({"index": idx, "content": content})
+            progress_bar.progress((idx + 1) / len(chunks))
+            status.text(f"Chunk {idx + 1}/{len(chunks)} terminé")
+
+        config = SchedulerConfig(
+            max_concurrent=max_concurrent,
+            send_interval=interval,
+            backoff_start=backoff,
+            max_retries=retries,
+            api_key=api_key,
+            progress_file=Path(progress_file),
+        )
+
+        scheduler = OpenAIScheduler(config, handler)
+        asyncio.run(scheduler.run(chunks))
+        progress_bar.progress(1.0)
+        st.success("Traitement terminé")
+        st.json(results)
+        st.download_button("Télécharger les résultats", json.dumps(results, indent=2), "results.json")


### PR DESCRIPTION
## Summary
- add a simple Streamlit UI (`scheduler_streamlit.py`) to run the OpenAI scheduler
- document PDF analyzer and the new Streamlit interface in README

## Testing
- `python -m py_compile openai_scheduler.py pdf_analyzer.py scheduler_streamlit.py`


------
https://chatgpt.com/codex/tasks/task_b_687816d0568c832b92f0b80c63062db8