### PR TITLE
Add advanced OpenAI controls to scheduler UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Optional parameters:
 - `--backoff` initial backoff delay in seconds (default 1)
 - `--retries` number of retries (default 3)
 - `--progress` path to the progress file (default `progress.txt`)
+- `--model` model name to use (default `gpt-3.5-turbo`)
+- `--temperature` sampling temperature (default 1.0)
+- `--top-p` nucleus sampling value (default 1.0)
+- `--presence-penalty` presence penalty (default 0.0)
+- `--frequency-penalty` frequency penalty (default 0.0)
+- `--max-tokens` maximum tokens in the response
 
 Results for each chunk are saved as `result_<index>.json`. To restart the pipeline without repeating finished chunks, keep the progress file.
 
@@ -51,6 +57,11 @@ Available UI settings:
 - **Intervalle entre envois** – delay between requests in seconds (default **4 s**)
 - **Backoff initial** – initial retry delay after an error (default **1 s**)
 - **Nombre de retries** – maximum number of retry attempts (default **3**)
+- **Modèle** – model name (default **gpt-3.5-turbo**)
+- **Température** – sampling temperature
+- **Top P** – nucleus sampling value
+- **Presence penalty** and **Frequency penalty** – penalties for token usage
+- **Max tokens** – limit for the response length
 
 Run it with:
 ```bash

--- a/scheduler_streamlit.py
+++ b/scheduler_streamlit.py
@@ -30,6 +30,14 @@ backoff = st.sidebar.number_input("Backoff initial (s)", value=1.0, min_value=0.
 retries = st.sidebar.number_input("Nombre de retries", value=3, min_value=0)
 progress_file = st.sidebar.text_input("Fichier de progrès", value="progress.txt")
 
+st.sidebar.subheader("Paramètres OpenAI")
+model = st.sidebar.text_input("Modèle", value="gpt-3.5-turbo")
+temperature = st.sidebar.slider("Température", 0.0, 2.0, 1.0, 0.1)
+top_p = st.sidebar.slider("Top P", 0.0, 1.0, 1.0, 0.05)
+presence_penalty = st.sidebar.slider("Presence penalty", -2.0, 2.0, 0.0, 0.1)
+frequency_penalty = st.sidebar.slider("Frequency penalty", -2.0, 2.0, 0.0, 0.1)
+max_tokens = st.sidebar.number_input("Max tokens", value=0, min_value=0)
+
 run = st.button("Lancer")
 
 if run:
@@ -58,6 +66,12 @@ if run:
             max_retries=retries,
             api_key=api_key,
             progress_file=Path(progress_file),
+            model=model,
+            temperature=temperature,
+            top_p=top_p,
+            presence_penalty=presence_penalty,
+            frequency_penalty=frequency_penalty,
+            max_tokens=max_tokens if max_tokens > 0 else None,
         )
 
         scheduler = OpenAIScheduler(config, handler)


### PR DESCRIPTION
## Summary
- expose OpenAI parameters in `SchedulerConfig` dataclass
- allow setting these options from command line and Streamlit UI
- document the new parameters in `README`

## Testing
- `python -m py_compile openai_scheduler.py scheduler_streamlit.py pdf_analyzer.py`

------
https://chatgpt.com/codex/tasks/task_b_68781c475258832bb69f53f2ffd6e092